### PR TITLE
勉強会 課題3

### DIFF
--- a/study-react/src/components/molecules/Category/index.tsx
+++ b/study-react/src/components/molecules/Category/index.tsx
@@ -1,0 +1,53 @@
+import { ChangeEvent, FC } from "react";
+import { useState, useCallback } from "react";
+import styled from "styled-components";
+
+export type Category = {
+  id: number;
+  value: string;
+};
+
+type Props = {
+  categoryList: Category[];
+  handleSelectCategory: (e: ChangeEvent<HTMLSelectElement>) => void;
+};
+
+export const useCategory = () => {
+  const [selectCategory, setSelectCategory] = useState<number>(0);
+  const handleSelectCategory = useCallback(
+    (e: ChangeEvent<HTMLSelectElement>) => {
+      console.log("handleSelectCategory", e.target.value);
+      const categoryId = Number(e.target.value);
+      setSelectCategory(categoryId);
+    },
+    [selectCategory]
+  );
+
+  return {
+    selectCategory,
+    handleSelectCategory,
+  };
+};
+
+export const CategoryList: FC<Props> = ({
+  categoryList,
+  handleSelectCategory,
+}) => {
+  return (
+    <StCategorySelect onChange={(e) => handleSelectCategory(e)}>
+      {categoryList.map((category) => (
+        <StCategoryOption key={category.id} value={category.id}>
+          {category.value}
+        </StCategoryOption>
+      ))}
+    </StCategorySelect>
+  );
+};
+
+const StCategorySelect = styled.select`
+  width: 320px;
+  margin-bottom: 16px;
+  padding: 8px;
+  font-size: 16px;
+`;
+const StCategoryOption = styled.option``;

--- a/study-react/src/components/molecules/Category/index.tsx
+++ b/study-react/src/components/molecules/Category/index.tsx
@@ -1,5 +1,4 @@
 import { ChangeEvent, FC } from "react";
-import { useState, useCallback } from "react";
 import styled from "styled-components";
 
 export type Category = {
@@ -10,23 +9,6 @@ export type Category = {
 type Props = {
   categoryList: Category[];
   handleSelectCategory: (e: ChangeEvent<HTMLSelectElement>) => void;
-};
-
-export const useCategory = () => {
-  const [selectCategory, setSelectCategory] = useState<number>(0);
-  const handleSelectCategory = useCallback(
-    (e: ChangeEvent<HTMLSelectElement>) => {
-      console.log("handleSelectCategory", e.target.value);
-      const categoryId = Number(e.target.value);
-      setSelectCategory(categoryId);
-    },
-    [selectCategory]
-  );
-
-  return {
-    selectCategory,
-    handleSelectCategory,
-  };
 };
 
 export const CategoryList: FC<Props> = ({

--- a/study-react/src/components/molecules/Counter/index.tsx
+++ b/study-react/src/components/molecules/Counter/index.tsx
@@ -1,25 +1,27 @@
-import { FC } from "react";
+import { FC, memo } from "react";
 import styled from "styled-components";
 
 type Props = {
   count: number;
   handleIncrement: () => void;
   handleDecrement: () => void;
+  resetCount: () => void;
 };
 
-export const Counter: FC<Props> = ({
-  count,
-  handleIncrement,
-  handleDecrement,
-}) => {
-  return (
-    <StCountWrapper>
-      <StButton onClick={handleDecrement}> - </StButton>
-      <div>{count}</div>
-      <StButton onClick={handleIncrement}> + </StButton>
-    </StCountWrapper>
-  );
-};
+export const Counter: FC<Props> = memo(
+  ({ count, handleIncrement, handleDecrement, resetCount }) => {
+    console.log("------------rerender component----------");
+
+    return (
+      <StCountWrapper>
+        <StButton onClick={handleDecrement}> - </StButton>
+        <div>{count}</div>
+        <StButton onClick={handleIncrement}> + </StButton>
+        <StButton onClick={resetCount}> × </StButton>
+      </StCountWrapper>
+    );
+  }
+);
 
 const StCountWrapper = styled.div`
   padding: 8px 0;

--- a/study-react/src/components/molecules/Expertise/index.tsx
+++ b/study-react/src/components/molecules/Expertise/index.tsx
@@ -1,15 +1,16 @@
-import { ChangeEvent, FC, useCallback, useState } from "react";
+import { ChangeEvent, FC } from "react";
 import styled from "styled-components";
 import { Category, CategoryList } from "../Category";
 import { Skill, SkillList } from "../Skill";
-import { Tag } from "../Tag";
+import { TagColor, Tag } from "../Tag";
 
 type Props = {
   categoryList: Category[];
   handleSelectCategory: (e: ChangeEvent<HTMLSelectElement>) => void;
   skillList: Skill[];
-  selectSkill: string[];
-  handleSelectSkill: (tag: string) => void;
+  selectSkill: Skill[];
+  handleSelectSkill: (tag: Skill) => void;
+  handleDeleteSkill: (tag: string) => void;
 };
 
 export const Expertise: FC<Props> = ({
@@ -18,13 +19,19 @@ export const Expertise: FC<Props> = ({
   skillList,
   selectSkill,
   handleSelectSkill,
+  handleDeleteSkill,
 }) => {
   return (
     <StWrapper>
       <StSelectedTagAreaWrapper>
         <StSelectedTagArea>
           {selectSkill.map((t) => (
-            <Tag key={t} tag={t} handleCloseTag={handleSelectSkill} />
+            <Tag
+              color={getColor(t.categoryId)}
+              key={t.id}
+              tag={t.value}
+              handleCloseTag={handleDeleteSkill}
+            />
           ))}
         </StSelectedTagArea>
       </StSelectedTagAreaWrapper>
@@ -42,6 +49,25 @@ export const Expertise: FC<Props> = ({
       </StSkillArea>
     </StWrapper>
   );
+};
+
+const getColor = (categoryId: number): TagColor => {
+  let color: TagColor = "blue";
+  switch (categoryId) {
+    case 1:
+    default:
+      break;
+    case 2:
+      color = "red";
+      break;
+    case 3:
+      color = "green";
+      break;
+    case 4:
+      color = "yellow";
+      break;
+  }
+  return color;
 };
 
 const StWrapper = styled.div`

--- a/study-react/src/components/molecules/Expertise/index.tsx
+++ b/study-react/src/components/molecules/Expertise/index.tsx
@@ -1,0 +1,65 @@
+import { ChangeEvent, FC, useCallback, useState } from "react";
+import styled from "styled-components";
+import { Category, CategoryList } from "../Category";
+import { Skill, SkillList } from "../Skill";
+import { Tag } from "../Tag";
+
+type Props = {
+  categoryList: Category[];
+  handleSelectCategory: (e: ChangeEvent<HTMLSelectElement>) => void;
+  skillList: Skill[];
+  selectSkill: string[];
+  handleSelectSkill: (tag: string) => void;
+};
+
+export const Expertise: FC<Props> = ({
+  categoryList,
+  handleSelectCategory,
+  skillList,
+  selectSkill,
+  handleSelectSkill,
+}) => {
+  return (
+    <StWrapper>
+      <StSelectedTagAreaWrapper>
+        <StSelectedTagArea>
+          {selectSkill.map((t) => (
+            <Tag key={t} tag={t} handleCloseTag={handleSelectSkill} />
+          ))}
+        </StSelectedTagArea>
+      </StSelectedTagAreaWrapper>
+      <StTitle>カテゴリ</StTitle>
+      <CategoryList
+        categoryList={categoryList}
+        handleSelectCategory={handleSelectCategory}
+      />
+      <StTitle>スキル</StTitle>
+      <StSkillArea>
+        <SkillList
+          skillList={skillList}
+          handleSelectSkill={handleSelectSkill}
+        />
+      </StSkillArea>
+    </StWrapper>
+  );
+};
+
+const StWrapper = styled.div`
+  padding: 16px 0;
+`;
+const StTitle = styled.h3`
+  margin-bottom: 8px;
+  font-size: 16px;
+`;
+const StSelectedTagAreaWrapper = styled.div`
+  margin-bottom: 16px;
+`;
+const StSelectedTagArea = styled.ul`
+  display: flex;
+  flex-wrap: wrap;
+`;
+const StSkillArea = styled.ul`
+  margin-top: 16px;
+  border: 1px solid;
+  padding: 8px;
+`;

--- a/study-react/src/components/molecules/Skill/index.tsx
+++ b/study-react/src/components/molecules/Skill/index.tsx
@@ -1,4 +1,4 @@
-import { FC, useState, useCallback } from "react";
+import { FC } from "react";
 import styled from "styled-components";
 
 export type Skill = {
@@ -7,30 +7,9 @@ export type Skill = {
   value: string;
 };
 
-export const useSkill = () => {
-  const [selectSkill, setSelectSkill] = useState<string[]>([]);
-  const handleSelectSkill = useCallback(
-    (tag: string) => {
-      if (selectSkill.some((e) => e === tag)) {
-        // 一致するタグがすでに存在する場合
-        setSelectSkill(selectSkill.filter((e) => e !== tag));
-      } else {
-        // なければ追加
-        setSelectSkill([...selectSkill, tag]);
-      }
-    },
-    [selectSkill]
-  );
-
-  return {
-    selectSkill,
-    handleSelectSkill,
-  };
-};
-
 type Props = {
   skillList: Skill[];
-  handleSelectSkill: (tag: string) => void;
+  handleSelectSkill: (tag: Skill) => void;
 };
 
 export const SkillList: FC<Props> = ({ skillList, handleSelectSkill }) => {
@@ -43,7 +22,7 @@ export const SkillList: FC<Props> = ({ skillList, handleSelectSkill }) => {
         <StSelectText
           key={t.id}
           value={t.value}
-          onClick={() => handleSelectSkill(t.value)}
+          onClick={() => handleSelectSkill(t)}
         >
           {t.value}
         </StSelectText>

--- a/study-react/src/components/molecules/Skill/index.tsx
+++ b/study-react/src/components/molecules/Skill/index.tsx
@@ -1,0 +1,59 @@
+import { FC, useState, useCallback } from "react";
+import styled from "styled-components";
+
+export type Skill = {
+  id: number;
+  categoryId: number;
+  value: string;
+};
+
+export const useSkill = () => {
+  const [selectSkill, setSelectSkill] = useState<string[]>([]);
+  const handleSelectSkill = useCallback(
+    (tag: string) => {
+      if (selectSkill.some((e) => e === tag)) {
+        // 一致するタグがすでに存在する場合
+        setSelectSkill(selectSkill.filter((e) => e !== tag));
+      } else {
+        // なければ追加
+        setSelectSkill([...selectSkill, tag]);
+      }
+    },
+    [selectSkill]
+  );
+
+  return {
+    selectSkill,
+    handleSelectSkill,
+  };
+};
+
+type Props = {
+  skillList: Skill[];
+  handleSelectSkill: (tag: string) => void;
+};
+
+export const SkillList: FC<Props> = ({ skillList, handleSelectSkill }) => {
+  if (skillList.length === 0) {
+    return <StSelectText>カテゴリを選択してください</StSelectText>;
+  }
+  return (
+    <>
+      {skillList.map((t) => (
+        <StSelectText
+          key={t.id}
+          value={t.value}
+          onClick={() => handleSelectSkill(t.value)}
+        >
+          {t.value}
+        </StSelectText>
+      ))}
+    </>
+  );
+};
+
+const StSelectText = styled.li`
+  :not(:last-of-type) {
+    margin-bottom: 8px;
+  }
+`;

--- a/study-react/src/components/molecules/Tag/index.tsx
+++ b/study-react/src/components/molecules/Tag/index.tsx
@@ -3,11 +3,16 @@ import styled from "styled-components";
 
 type Props = {
   tag: string;
-  handlePushTag: (addTag: string) => void;
+  handleCloseTag: (tag: string) => void;
 };
 
-export const Tag: FC<Props> = ({ tag, handlePushTag }) => {
-  return <StTag onClick={() => handlePushTag(tag)}>{tag}</StTag>;
+export const Tag: FC<Props> = ({ tag, handleCloseTag }) => {
+  return (
+    <StTag>
+      <StTagText>{tag}</StTagText>
+      <StCloseButton onClick={() => handleCloseTag(tag)}>×</StCloseButton>
+    </StTag>
+  );
 };
 
 const StTag = styled.li`
@@ -15,6 +20,20 @@ const StTag = styled.li`
   color: #fff;
   border-radius: 24px;
   margin-right: 8px;
+  margin-bottom: 8px;
   padding: 4px 12px;
   font-size: 12px;
+`;
+const StTagText = styled.span`
+  display: inline-block;
+  margin-right: 8px;
+`;
+const StCloseButton = styled.button`
+  appearance: none;
+  cursor: pointer;
+  border: none;
+  outline: none;
+  font-size: 16px;
+  color: #fff;
+  vertical-align: middle;
 `;

--- a/study-react/src/components/molecules/Tag/index.tsx
+++ b/study-react/src/components/molecules/Tag/index.tsx
@@ -1,22 +1,42 @@
 import { FC } from "react";
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 
+export type TagColor = "blue" | "red" | "green" | "yellow";
 type Props = {
   tag: string;
+  color?: TagColor;
   handleCloseTag: (tag: string) => void;
 };
 
-export const Tag: FC<Props> = ({ tag, handleCloseTag }) => {
+export const Tag: FC<Props> = ({ tag, color = "blue", handleCloseTag }) => {
   return (
-    <StTag>
+    <StTag color={color}>
       <StTagText>{tag}</StTagText>
       <StCloseButton onClick={() => handleCloseTag(tag)}>×</StCloseButton>
     </StTag>
   );
 };
 
-const StTag = styled.li`
-  background-color: rgb(27, 161, 255);
+const getStyle = (color: TagColor): string => {
+  let style = "rgb(27, 161, 255)";
+  switch (color) {
+    case "red":
+      style = "rgb(239, 83, 80)";
+      break;
+    case "green":
+      style = "rgb(156, 204, 101)";
+      break;
+    case "yellow":
+      style = "rgb(255, 167, 38)";
+      break;
+    case "blue":
+    default:
+  }
+  return style;
+};
+
+const StTag = styled.li<{ color: TagColor }>`
+  background-color: ${(props) => getStyle(props.color)};
   color: #fff;
   border-radius: 24px;
   margin-right: 8px;

--- a/study-react/src/components/molecules/TagArea/index.tsx
+++ b/study-react/src/components/molecules/TagArea/index.tsx
@@ -7,14 +7,14 @@ export type TagList = { id: string; value: string }[];
 type Props = {
   tag: string[];
   tagList: TagList;
-  handleClearTag: () => void;
+  handleAllClearTag: () => void;
   handlePushTag: (addTag: string) => void;
 };
 
 export const TagArea: FC<Props> = ({
   tag,
   tagList,
-  handleClearTag,
+  handleAllClearTag,
   handlePushTag,
 }) => {
   return (
@@ -22,10 +22,10 @@ export const TagArea: FC<Props> = ({
       <StSelectedTagAreaWrapper>
         <StSelectedTagArea>
           {tag.map((t) => (
-            <Tag key={t} tag={t} handlePushTag={handlePushTag} />
+            <Tag key={t} tag={t} handleCloseTag={handlePushTag} />
           ))}
         </StSelectedTagArea>
-        <div onClick={handleClearTag}>×</div>
+        <div onClick={handleAllClearTag}>×</div>
       </StSelectedTagAreaWrapper>
       <StSelectAreaWrapper>
         <StSelectArea>

--- a/study-react/src/components/organisms/Footer/index.tsx
+++ b/study-react/src/components/organisms/Footer/index.tsx
@@ -10,11 +10,10 @@ export const Footer: FC = () => {
 };
 
 const StFooterRoot = styled.footer`
-  position: fixed;
-  bottom: 0;
   background-color: rgb(34, 34, 34);
   color: rgb(255, 255, 255);
   font-size: 20px;
   width: 100%;
+  margin-top: 32px;
   padding: 8px;
 `;

--- a/study-react/src/components/organisms/Top/hooks.ts
+++ b/study-react/src/components/organisms/Top/hooks.ts
@@ -1,4 +1,5 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, ChangeEvent } from "react";
+import { Skill } from "../../molecules/Skill";
 
 export const useCount = () => {
   const [count, setCount] = useState(0);
@@ -35,4 +36,51 @@ export const useTagList = () => {
   };
 
   return { tag, handleClearTag, handlePushTag };
+};
+
+export const useCategory = () => {
+  const [selectCategory, setSelectCategory] = useState<number>(0);
+  const handleSelectCategory = useCallback(
+    (e: ChangeEvent<HTMLSelectElement>) => {
+      console.log("handleSelectCategory", e.target.value);
+      const categoryId = Number(e.target.value);
+      setSelectCategory(categoryId);
+    },
+    [selectCategory]
+  );
+
+  return {
+    selectCategory,
+    handleSelectCategory,
+  };
+};
+
+export const useSkill = () => {
+  const [selectSkill, setSelectSkill] = useState<Skill[]>([]);
+  const handleSelectSkill = useCallback(
+    (tag: Skill) => {
+      // 存在しなければ追加
+      const isExist = selectSkill.some((e) => e.value === tag.value);
+      if (!isExist) {
+        setSelectSkill([...selectSkill, tag]);
+      }
+    },
+    [selectSkill]
+  );
+  const handleDeleteSkill = useCallback(
+    (tag: string) => {
+      // 一致するタグが存在するかチェック
+      if (selectSkill.some((e) => e.value === tag)) {
+        // 該当のスキルを除外してset
+        setSelectSkill(selectSkill.filter((e) => e.value !== tag));
+      }
+    },
+    [selectSkill]
+  );
+
+  return {
+    selectSkill,
+    handleSelectSkill,
+    handleDeleteSkill,
+  };
 };

--- a/study-react/src/components/organisms/Top/hooks.ts
+++ b/study-react/src/components/organisms/Top/hooks.ts
@@ -1,0 +1,38 @@
+import { useState, useCallback } from "react";
+
+export const useCount = () => {
+  const [count, setCount] = useState(0);
+  console.log("----------rendering----------");
+  const handleIncrement = useCallback(() => {
+    console.log("----------Count rendering----------");
+    return setCount(count + 1);
+  }, [count]);
+  const handleDecrement = useCallback(() => {
+    console.log("----------Count rendering----------");
+    // カウントが0以下にならないようにする
+    if (count === 0) return;
+    setCount(count - 1);
+  }, [count]);
+  const resetCount = useCallback(() => {
+    console.log("----------execute resetCount----------");
+    return setCount(0);
+  }, []);
+
+  return { count, handleIncrement, handleDecrement, resetCount };
+};
+
+export const useTagList = () => {
+  const [tag, setTag] = useState<string[]>([]);
+  const handleClearTag = useCallback(() => setTag([]), [tag]);
+  const handlePushTag = (addTag: string) => {
+    if (tag.some((e) => e === addTag)) {
+      // 一致するタグがすでに存在する場合
+      setTag(tag.filter((e) => e !== addTag));
+    } else {
+      // なければ追加
+      setTag([...tag, addTag]);
+    }
+  };
+
+  return { tag, handleClearTag, handlePushTag };
+};

--- a/study-react/src/components/organisms/Top/hooks.ts
+++ b/study-react/src/components/organisms/Top/hooks.ts
@@ -59,9 +59,11 @@ export const useSkill = () => {
   const [selectSkill, setSelectSkill] = useState<Skill[]>([]);
   const handleSelectSkill = useCallback(
     (tag: Skill) => {
-      // 存在しなければ追加
-      const isExist = selectSkill.some((e) => e.value === tag.value);
-      if (!isExist) {
+      if (selectSkill.some((e) => e.value === tag.value)) {
+        // 既に存在していれば該当のスキルを除外してset
+        setSelectSkill(selectSkill.filter((e) => e.value !== tag.value));
+      } else {
+        // 存在しなければ追加
         setSelectSkill([...selectSkill, tag]);
       }
     },

--- a/study-react/src/components/organisms/Top/index.tsx
+++ b/study-react/src/components/organisms/Top/index.tsx
@@ -1,37 +1,58 @@
-import { FC, useState } from "react";
+import { FC, useState, useEffect } from "react";
 import styled from "styled-components";
 import { Counter } from "../../molecules/Counter";
 import { TagArea, TagList } from "../../molecules/TagArea";
+import { Skill, useSkill } from "../../molecules/Skill";
+import { Category, useCategory } from "../../molecules/Category";
+import { Expertise } from "../../molecules/Expertise";
+import { useCount, useTagList } from "./hooks";
 
 export const Top: FC = () => {
-  const [count, setCount] = useState(0);
-  const handleIncrement = () => setCount(count + 1);
-  const handleDecrement = () => {
-    // カウントが0以下にならないようにする
-    if (count === 0) return;
-    setCount(count - 1);
-  };
+  const { count, handleIncrement, handleDecrement, resetCount } = useCount();
+  const { tag, handleClearTag, handlePushTag } = useTagList();
+  const { selectCategory, handleSelectCategory } = useCategory();
+  const { selectSkill, handleSelectSkill } = useSkill();
 
-  const [tag, setTag] = useState<string[]>([]);
-  const handleClearTag = () => setTag([]);
-  const handlePushTag = (addTag: string) => {
-    if (tag.some((e) => e === addTag)) {
-      // 一致するタグがすでに存在する場合
-      setTag(tag.filter((e) => e !== addTag));
-    } else {
-      // なければ追加
-      setTag([...tag, addTag]);
+  const [tagList, setTagList] = useState<TagList>([]);
+  const [skillList, setSkillList] = useState<Skill[]>([]);
+  const [categoryList, setCategoryList] = useState<Category[]>([]);
+
+  // 初回のみ呼び出し
+  useEffect(() => {
+    console.log("mounted");
+
+    const getTag = async () => {
+      const res = await fetch("/api/tag");
+      const data: TagList = await res.json();
+
+      setTagList(data);
+    };
+    getTag();
+
+    const getCategory = async () => {
+      const res = await fetch("/api/category");
+      return await res.json();
+    };
+    getCategory().then((categoryData: Category[]) => {
+      setCategoryList(categoryData);
+    });
+  }, []);
+
+  // selectCategoryの値が変更されたとき呼び出し
+  useEffect(() => {
+    console.log("change selectCategory", selectCategory);
+    if (selectCategory === 0) {
+      setSkillList([]);
+      return;
     }
-  };
-  const tagList: TagList = [
-    { id: "tag1", value: "React" },
-    { id: "tag2", value: "Vue.js" },
-    { id: "tag3", value: "Angular" },
-    { id: "tag4", value: "Next.js" },
-    { id: "tag5", value: "Nuxt.js" },
-    { id: "tag6", value: "jQuery" },
-    { id: "tag7", value: "Gatsby.js" },
-  ];
+    const getSkill = async () => {
+      const res = await fetch(`/api/skill/${selectCategory}`);
+      return await res.json();
+    };
+    getSkill().then((skillData: Skill[]) => {
+      setSkillList(skillData);
+    });
+  }, [selectCategory]);
 
   return (
     <StTopRoot>
@@ -43,6 +64,7 @@ export const Top: FC = () => {
             count={count}
             handleIncrement={handleIncrement}
             handleDecrement={handleDecrement}
+            resetCount={resetCount}
           />
         </StArticle>
         <StArticle>
@@ -50,8 +72,18 @@ export const Top: FC = () => {
           <TagArea
             tag={tag}
             tagList={tagList}
-            handleClearTag={handleClearTag}
+            handleAllClearTag={handleClearTag}
             handlePushTag={handlePushTag}
+          />
+        </StArticle>
+        <StArticle>
+          <StArticleTitle>興味のある言語/フレームワーク</StArticleTitle>
+          <Expertise
+            categoryList={categoryList}
+            handleSelectCategory={handleSelectCategory}
+            skillList={skillList}
+            selectSkill={selectSkill}
+            handleSelectSkill={handleSelectSkill}
           />
         </StArticle>
       </StContent>
@@ -68,7 +100,7 @@ const StContent = styled.div`
   background-color: rgb(255, 255, 255);
 `;
 
-const StTopTitle = styled.p`
+const StTopTitle = styled.h1`
   background-color: rgb(255, 255, 255);
   padding: 16px;
   margin-bottom: 8px;
@@ -85,6 +117,7 @@ const StArticle = styled.article`
   border-radius: 3px;
 `;
 
-const StArticleTitle = styled.p`
+const StArticleTitle = styled.h2`
+  font-size: 20px;
   font-weight: bold;
 `;

--- a/study-react/src/components/organisms/Top/index.tsx
+++ b/study-react/src/components/organisms/Top/index.tsx
@@ -2,16 +2,16 @@ import { FC, useState, useEffect } from "react";
 import styled from "styled-components";
 import { Counter } from "../../molecules/Counter";
 import { TagArea, TagList } from "../../molecules/TagArea";
-import { Skill, useSkill } from "../../molecules/Skill";
-import { Category, useCategory } from "../../molecules/Category";
+import { Skill } from "../../molecules/Skill";
+import { Category } from "../../molecules/Category";
 import { Expertise } from "../../molecules/Expertise";
-import { useCount, useTagList } from "./hooks";
+import { useCount, useTagList, useSkill, useCategory } from "./hooks";
 
 export const Top: FC = () => {
   const { count, handleIncrement, handleDecrement, resetCount } = useCount();
   const { tag, handleClearTag, handlePushTag } = useTagList();
   const { selectCategory, handleSelectCategory } = useCategory();
-  const { selectSkill, handleSelectSkill } = useSkill();
+  const { selectSkill, handleSelectSkill, handleDeleteSkill } = useSkill();
 
   const [tagList, setTagList] = useState<TagList>([]);
   const [skillList, setSkillList] = useState<Skill[]>([]);
@@ -84,6 +84,7 @@ export const Top: FC = () => {
             skillList={skillList}
             selectSkill={selectSkill}
             handleSelectSkill={handleSelectSkill}
+            handleDeleteSkill={handleDeleteSkill}
           />
         </StArticle>
       </StContent>

--- a/study-react/src/pages/api/category/index.ts
+++ b/study-react/src/pages/api/category/index.ts
@@ -1,0 +1,22 @@
+import { NextApiRequest, NextApiResponse } from "Next";
+
+type Category = {
+  id: number;
+  value: string;
+};
+const data: Category[] = [
+  {
+    id: 0,
+    value: "選択されていません",
+  },
+  { id: 1, value: "サーバーサイド" },
+  { id: 2, value: "フロントエンド" },
+  { id: 3, value: "インフラ" },
+  { id: 4, value: "アプリ" },
+];
+
+const handler = (req: NextApiRequest, res: NextApiResponse) => {
+  res.status(200).json(data);
+};
+
+export default handler;

--- a/study-react/src/pages/api/skill/[categoryId].ts
+++ b/study-react/src/pages/api/skill/[categoryId].ts
@@ -1,0 +1,97 @@
+import { NextApiRequest, NextApiResponse } from "Next";
+import { Skill, SkillList } from "../../../components/molecules/Skill";
+
+const skill1: Skill[] = [
+  { id: 101, categoryId: 1, value: "Ruby" },
+  { id: 102, categoryId: 1, value: "PHP" },
+  { id: 103, categoryId: 1, value: "Python" },
+  { id: 104, categoryId: 1, value: "Go" },
+  { id: 105, categoryId: 1, value: "Java" },
+  { id: 121, categoryId: 1, value: "Ruby on Rails" },
+  { id: 122, categoryId: 1, value: "Laravel" },
+  { id: 123, categoryId: 1, value: "Symfony" },
+  { id: 124, categoryId: 1, value: "Django" },
+  { id: 125, categoryId: 1, value: "Flask" },
+  { id: 126, categoryId: 1, value: "Gin" },
+  { id: 127, categoryId: 1, value: "Revel" },
+  { id: 128, categoryId: 1, value: "Spring Boot" },
+];
+
+const skill2: Skill[] = [
+  { id: 201, categoryId: 2, value: "JavaScript" },
+  { id: 202, categoryId: 2, value: "HTML" },
+  { id: 203, categoryId: 2, value: "CSS" },
+  { id: 221, categoryId: 2, value: "TypeScript" },
+  { id: 222, categoryId: 2, value: "React" },
+  { id: 223, categoryId: 2, value: "Vue.js" },
+  { id: 224, categoryId: 2, value: "Svelte" },
+  { id: 225, categoryId: 2, value: "Solid" },
+  { id: 226, categoryId: 2, value: "Lit" },
+  { id: 227, categoryId: 2, value: "Alpine.js" },
+  { id: 228, categoryId: 2, value: "Preact" },
+  { id: 229, categoryId: 2, value: "Stimulus" },
+  { id: 230, categoryId: 2, value: "Angular" },
+  { id: 231, categoryId: 2, value: "Ember" },
+  { id: 232, categoryId: 2, value: "Next.js" },
+  { id: 233, categoryId: 2, value: "Nuxt" },
+];
+
+const skill3: Skill[] = [
+  { id: 301, categoryId: 3, value: "AWS" },
+  { id: 302, categoryId: 3, value: "GCP" },
+  { id: 303, categoryId: 3, value: "Azure" },
+  { id: 304, categoryId: 3, value: "Firebase" },
+  { id: 305, categoryId: 3, value: "Heroku" },
+  { id: 306, categoryId: 3, value: "Docker" },
+  { id: 307, categoryId: 3, value: "Kubernates" },
+  { id: 308, categoryId: 3, value: "Terraform" },
+  { id: 309, categoryId: 3, value: "Ansible" },
+  { id: 310, categoryId: 3, value: "Chef" },
+  { id: 311, categoryId: 3, value: "Datadog" },
+  { id: 312, categoryId: 3, value: "Mackerel" },
+  { id: 313, categoryId: 3, value: "Prometheus" },
+  { id: 314, categoryId: 3, value: "Zabbbix" },
+  { id: 315, categoryId: 3, value: "Sentry" },
+  { id: 316, categoryId: 3, value: "GitHub" },
+  { id: 317, categoryId: 3, value: "GitHub Actions" },
+  { id: 318, categoryId: 3, value: "CircleCI" },
+  { id: 319, categoryId: 3, value: "Jenkins" },
+];
+
+const skill4: Skill[] = [
+  { id: 401, categoryId: 4, value: "Objective-C" },
+  { id: 402, categoryId: 4, value: "Swift" },
+  { id: 403, categoryId: 4, value: "AndroidJava" },
+  { id: 404, categoryId: 4, value: "Kotlin" },
+  { id: 411, categoryId: 4, value: "Xamarin" },
+  { id: 412, categoryId: 4, value: "Cordova" },
+  { id: 413, categoryId: 4, value: "React Native" },
+  { id: 414, categoryId: 4, value: "Flutter" },
+];
+
+const handler = (req: NextApiRequest, res: NextApiResponse) => {
+  const { categoryId } = req.query;
+  const data = getData(Number(categoryId));
+  res.status(200).json(data);
+};
+const getData = (id: number) => {
+  let data: Skill[] = [];
+  switch (id) {
+    case 1:
+      data = skill1;
+      break;
+    case 2:
+      data = skill2;
+      break;
+    case 3:
+      data = skill3;
+      break;
+    case 4:
+      data = skill4;
+      break;
+    default:
+      break;
+  }
+  return data;
+};
+export default handler;

--- a/study-react/src/pages/api/tag/index.ts
+++ b/study-react/src/pages/api/tag/index.ts
@@ -1,0 +1,18 @@
+import { NextApiRequest, NextApiResponse } from "Next";
+import { TagList } from "src/components/molecules/TagArea";
+
+const data: TagList = [
+  { id: "tag1", value: "React" },
+  { id: "tag2", value: "Vue.js" },
+  { id: "tag3", value: "Angular" },
+  { id: "tag4", value: "Next.js" },
+  { id: "tag5", value: "Nuxt.js" },
+  { id: "tag6", value: "jQuery" },
+  { id: "tag7", value: "Gatsby.js" },
+];
+
+const handler = (req: NextApiRequest, res: NextApiResponse) => {
+  res.status(200).json(data);
+};
+
+export default handler;


### PR DESCRIPTION
https://adven-blog.vercel.app/article/4E3eugLY5pmbkzv82zs48l

- 勉強会第3回時の内容追加
- 興味のある言語に関する処理を実装
  - カテゴリを取得・選択する処理
  - スキルを取得・選択・表示する処理
タグのコンポーネントを共通で使えるよう修正
  - 色分け用のprops追加 等


もしかしてuseEffect周りも切り分けできる…？と思いつつ、
mount時の取得処理が2回走ることになりそうだったので手を付けられず
（getTagとgetCategoryでuseEffectを分けたら2回走る気がする…？）

他も色々useCallbackのタイミング考慮が足りてないですが、いったんあげ
